### PR TITLE
Rework welcome note + restore action (AFTR-419, AFTR-420)

### DIFF
--- a/FlatNote/NoteLibraryView.swift
+++ b/FlatNote/NoteLibraryView.swift
@@ -19,6 +19,17 @@ struct NoteLibraryView: View {
         }
     }
 
+    private func restoreWelcomeNote() {
+        guard let note = store.restoreWelcomeNote() else { return }
+        // Close Settings first, then open the restored note so the sheet
+        // dismissal and the navigation push do not race.
+        showingSettings = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+            newNoteID = nil
+            selectedNote = note
+        }
+    }
+
     /// Parses `flatnote://open?path=<abs path>` and opens the companion note.
     private func openPairedNote(from url: URL) -> NoteFile? {
         guard url.host == "open",
@@ -189,7 +200,8 @@ struct NoteLibraryView: View {
                 SettingsView(
                     noteCount: store.notes.count,
                     noteURLs: store.markdownExportURLs(),
-                    iCloudAvailable: store.iCloudAvailable
+                    iCloudAvailable: store.iCloudAvailable,
+                    onRestoreWelcome: restoreWelcomeNote
                 )
             }
             .alert(
@@ -214,6 +226,7 @@ struct SettingsView: View {
     let noteCount: Int
     let noteURLs: [URL]
     let iCloudAvailable: Bool
+    let onRestoreWelcome: () -> Void
     @Environment(\.dismiss) private var dismiss
 
     private var appVersion: String {
@@ -246,6 +259,18 @@ struct SettingsView: View {
                     } footer: {
                         Text("Share or save every note as .md files. Your notes are also available in the Files app under FlatNote.")
                     }
+                }
+
+                Section {
+                    Button {
+                        onRestoreWelcome()
+                    } label: {
+                        Label("Restore Welcome Note", systemImage: "arrow.counterclockwise")
+                    }
+                } header: {
+                    Text("Welcome Note")
+                } footer: {
+                    Text("Brings back the \"Welcome to FlatNote\" guide. If one already exists, it is added as a new copy so your edits are kept.")
                 }
 
                 Section {

--- a/FlatNote/NoteStore.swift
+++ b/FlatNote/NoteStore.swift
@@ -93,8 +93,14 @@ class NoteStore {
                 self.storageURL = resolved
                 self.iCloudAvailable = iCloud
                 self.loadNotes()
-                if self.notes.isEmpty {
-                    self.createWelcomeNote()
+                // Seed the welcome note only on the very first launch. After
+                // that the user's choice to delete it is respected; they can
+                // restore it deliberately from Settings.
+                if !self.hasSeededWelcome {
+                    if self.notes.isEmpty {
+                        self.createWelcomeNote()
+                    }
+                    self.hasSeededWelcome = true
                 }
             }
         }
@@ -462,50 +468,99 @@ class NoteStore {
         return candidate
     }
 
+    /// The single source for the welcome note's contents, used both for the
+    /// first-launch seed and for the "Restore Welcome Note" action so the two
+    /// can never drift. Each line shows the markdown to type and what it becomes.
+    static let welcomeMarkdown = """
+    # Welcome to FlatNote
+
+    FlatNote formats your writing as you type. Type the plain markdown on the left, and it becomes the styled text on the right.
+
+    ## Italic and bold
+
+    `*italic*` becomes *italic*
+
+    `**bold**` becomes **bold**
+
+    `***bold italic***` becomes ***bold italic***
+
+    `~~strikethrough~~` becomes ~~strikethrough~~
+
+    Wrap a word in backticks for `inline code`.
+
+    ## Headings
+
+    Start a line with `#` for a heading. Add more hashes for smaller ones:
+
+    ### Like this third-level heading
+
+    ## Lists
+
+    Start a line with `-` for a bullet:
+
+    - A bullet
+    - Another bullet
+
+    ## Checklists
+
+    Add `[ ]` after the dash for a checkbox. Tap or click the box to toggle it:
+
+    - [ ] Something to do
+    - [x] Something done
+
+    ## Links
+
+    `[words](https://example.com)` becomes [words](https://example.com)
+
+    ## Quotes
+
+    Start a line with `>` for a quote:
+
+    > Like this
+
+    ## Why markdown
+
+    Your notes are plain text. Every one is a .md file you can open in any editor, on any device, today or in twenty years.
+
+    That is the point. Some formats lock your words inside a single program. Miss an update, switch devices, or let a subscription lapse, and your own writing can become hard to reach. Plain text never does. It belongs to you, not to an app.
+
+    FlatNote just makes plain text pleasant to write. The freedom was always yours.
+
+    ---
+
+    Your notes live as plain .md files in your own Files, under FlatNote. Start a new note whenever you are ready.
+
+    Deleted this note by accident? You can bring it back anytime from Settings.
+    """
+
+    /// Persisted so the welcome note is seeded only once, ever. After that,
+    /// deleting it stays deleted unless the user restores it on purpose.
+    private static let didSeedWelcomeKey = "FlatNoteDidSeedWelcome"
+    private var hasSeededWelcome: Bool {
+        get { UserDefaults.standard.bool(forKey: Self.didSeedWelcomeKey) }
+        set { UserDefaults.standard.set(newValue, forKey: Self.didSeedWelcomeKey) }
+    }
+
     private func createWelcomeNote() {
-        let content = """
-        # Welcome to FlatNote
-
-        FlatNote formats your writing as you type. Here is how, with the symbol to type on the left and what it becomes below it.
-
-        ## Headings
-
-        Start a line with `#` for a big heading, or `##` for a smaller one:
-
-        ## A smaller heading
-
-        ## Bold and italic
-
-        Type `**two asterisks**` around words for **two asterisks** bold, or `*one asterisk*` for *one asterisk* italic. Type `~~tildes~~` for ~~strikethrough~~.
-
-        ## Lists
-
-        Start a line with `-` for a bullet:
-
-        - A bullet
-        - Another bullet
-
-        Add `[ ]` after the dash for a checkbox you can tap:
-
-        - [ ] Something to do
-        - [x] Something done
-
-        ## Links
-
-        Type `[words](https://example.com)` to make a [link](https://example.com).
-
-        ## Quotes
-
-        Start a line with `>` for a quote:
-
-        > Like this
-
-        ---
-
-        That is everything. Your notes are saved as plain .md files that belong to you. Tap the compose button to start writing.
-        """
         let url = documentsURL.appendingPathComponent("Welcome to FlatNote.md")
-        try? coordinatedWrite(content, to: url)
+        try? coordinatedWrite(Self.welcomeMarkdown, to: url)
         loadNotes()
+    }
+
+    /// Recreates the welcome note on demand. If one already exists, its name is
+    /// uniqued so the user's edited copy is never overwritten. Returns the new
+    /// note so the caller can open it.
+    @discardableResult
+    func restoreWelcomeNote() -> NoteFile? {
+        let url = uniqueDestination(for: "Welcome to FlatNote.md")
+        do {
+            try coordinatedWrite(Self.welcomeMarkdown, to: url)
+        } catch {
+            lastError = "Could not restore the welcome note."
+            return nil
+        }
+        hasSeededWelcome = true
+        loadNotes()
+        return notes.first(where: { $0.url == url })
     }
 }

--- a/FlatNoteTests/FlatNoteTests.swift
+++ b/FlatNoteTests/FlatNoteTests.swift
@@ -115,6 +115,44 @@ struct NoteStoreTests {
         #expect(!store.notes.contains(where: { $0.id == note.id }))
     }
 
+    // MARK: Welcome note (AFTR-419 / AFTR-420)
+
+    @Test func restoreWelcomeNoteCreatesIt() {
+        let (store, tmp) = makeTempStore()
+        defer { cleanup(tmp) }
+
+        let note = store.restoreWelcomeNote()
+        #expect(note != nil)
+        #expect(note?.displayName == "Welcome to FlatNote")
+        #expect(store.readContent(of: note!) == NoteStore.welcomeMarkdown)
+    }
+
+    @Test func restoreWelcomeNoteKeepsExistingCopy() {
+        let (store, tmp) = makeTempStore()
+        defer { cleanup(tmp) }
+
+        let original = tmp.appendingPathComponent("Welcome to FlatNote.md")
+        try! "my edited welcome".write(to: original, atomically: true, encoding: .utf8)
+
+        let restored = store.restoreWelcomeNote()
+        #expect(restored != nil)
+        // The user's edited original is untouched...
+        #expect((try? String(contentsOf: original, encoding: .utf8)) == "my edited welcome")
+        // ...and the restored copy is a distinct, uniquely named file.
+        #expect(restored?.url != original)
+        #expect(store.readContent(of: restored!) == NoteStore.welcomeMarkdown)
+    }
+
+    @Test func welcomeMarkdownShowsLiveExamples() {
+        // AFTR-420: the guide must pair the markdown with its rendered result
+        // rather than describe syntax in prose, and frame markdown around freedom.
+        let md = NoteStore.welcomeMarkdown
+        #expect(md.contains("`*italic*` becomes *italic*"))
+        #expect(md.contains("`**bold**` becomes **bold**"))
+        #expect(md.contains("## Why markdown"))
+        #expect(!md.contains("two asterisks"))   // old prose phrasing is gone
+    }
+
     @Test func previewTruncatesLongContent() {
         let (store, tmp) = makeTempStore()
         defer { cleanup(tmp) }
@@ -444,6 +482,16 @@ struct MarkdownRenderTests {
         #expect(html.contains("md-bold"))
         #expect(html.contains(">bold<"))
         #expect(!html.contains("md-italic"))   // single-pass tokenizer guard
+    }
+
+    @Test func welcomeExampleRendersBothCodeAndResult() throws {
+        // The welcome guide's pattern: `*italic*` becomes *italic* must render
+        // the literal markdown as code (asterisks visible) AND the styled result.
+        let render = try makeRenderer()
+        let html = render("`*italic*` becomes *italic*")
+        #expect(html.contains("md-code"))      // literal markdown, shown as code
+        #expect(html.contains(">*italic*<"))   // asterisks stay visible in the code span
+        #expect(html.contains("md-italic"))    // the rendered result
     }
 
     @Test func htmlIsEscaped() throws {


### PR DESCRIPTION
## AFTR-420 — Rework the welcome content
The guide described markdown in prose ("two asterisks"). It now shows each feature as the markdown and its result side by side, using the editor's own inline-code rendering (backticks hidden, asterisks visible):

- `` `*italic*` `` becomes *italic*, `` `**bold**` `` becomes **bold**, etc.
- Live examples for headings, lists, tappable checklists, links, quotes.
- New **Why markdown** section reframed around freedom and longevity: plain text you can open on any device, today or in twenty years; some formats lock your words inside one program or behind a version/subscription. Brand-neutral, in FlatNote's voice (no emoji, em dashes, or exclamation marks).

## AFTR-419 — Restore the welcome note
The note is editable and could be deleted with no way back.

- **Settings → Restore Welcome Note** recreates it. If a copy already exists, the name is uniqued so the user's edits are never overwritten.
- The welcome note is now seeded **only once ever** (persisted flag), so deleting it stays deleted unless restored on purpose.
- Seed and restore share one `NoteStore.welcomeMarkdown` constant, so the content can't drift between them.

## Verification
- macOS build: succeeded
- Test suite: **47 tests, 0 failures** (4 new): restore creates the note, restore preserves an existing edited copy, the guide pairs markdown with rendered output + includes the freedom framing, and an example line renders both the literal code and the styled result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)